### PR TITLE
Here's the rewritten message:

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,21 @@
+Water AI
+
+This project, "Water AI", is a derivative work of the "Ii agent" project.
+The "Ii agent" project was originally licensed under the Apache License, Version 2.0.
+The original "Ii agent" project can be found at: https://github.com/Intelligent-Internet/ii-agent
+
+--------------------------------------------------------------------------
+
+   Copyright 2025 John Victor
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ A robust architecture featuring client-side components (UI, WebAssembly for loca
 
 Core components are envisioned as open-source (e.g., Apache 2.0, MIT license) to foster transparency, trust, community contribution, and rapid adoption, aligning with the "gift for humanity" philosophy. This will be balanced with sustainable monetization. Community engagement via GitHub, forums, and clear contribution guidelines.
 
+This project, Water AI, builds upon the foundations laid by the "Ii agent" project (https://github.com/Intelligent-Internet/ii-agent). The "Ii agent" project is also open-sourced under the Apache License 2.0. We gratefully acknowledge the work of the "Ii agent" contributors.
+
 **10. Business Model: Sustainable Impact & Growth**
 
 Water AI is envisioned as a gift to humanity, with a sustainable model that balances accessibility with operational sustainability. Our approach ensures the platform can grow while remaining true to its mission of democratizing advanced AI capabilities.


### PR DESCRIPTION
Add Apache 2.0 compliance artifacts

This commit introduces changes to ensure your project's compliance with the Apache License 2.0, reflecting its derivation from the "Ii agent" open-source project.

Changes include:
- Addition of a `NOTICE` file:
    - States that "Water AI" is derived from "Ii agent".
    - Includes the Apache 2.0 license boilerplate.
    - Sets copyright for "Water AI" to "2025 John Victor".
- Modification of `README.md`:
    - Added an acknowledgement in the "Open Source Strategy" section regarding the project's origins from "Ii agent" and its Apache 2.0 license.

Guidance has also been provided for developers to add modification notices to any source files taken and modified from the original "Ii agent" project, as per Apache 2.0 Section 4b.