### PR TITLE
Refactor: Simplify build process to use uv exclusively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,7 @@
-.PHONY: install-uv build
+.PHONY: build
 
-install-uv:
-	@uv --version > /dev/null 2>&1 || (echo "uv not found, installing..." && pip install uv)
-	@uv --version > /dev/null 2>&1 && echo "uv is already installed."
-
-build: install-uv
-	@if [ -d ".venv" ]; then \
-		echo ".venv already exists."; \
-	else \
-		echo "Creating .venv..."; \
-		uv venv .venv; \
-	fi
-	@uv pip sync --python .venv/bin/python requirements.txt
+build:
+	@echo "Ensuring .venv is created..."
+	@uv venv .venv
+	@echo "Syncing dependencies..."
+	@uv pip sync requirements.txt

--- a/README.md
+++ b/README.md
@@ -123,9 +123,8 @@ To set up and run this project, follow these steps:
 
 3.  **Run `make build` to set up the project's virtual environment and install dependencies using uv.**
     This command will:
-    * Verify `uv` is installed (or prompt you to install it).
-    * Create a virtual environment named `.venv` if it doesn't exist.
-    * Install dependencies from `requirements.txt` into the virtual environment.
+    * Create a virtual environment named `.venv` (or update it if it already exists).
+    * Install/sync dependencies from `requirements.txt` into the virtual environment using `uv pip sync`.
     *Note: Ensure you are in the root directory of the cloned repository when running this command.*
 
 4.  **Set up Environment Variables:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,11 @@ Pillow
 pexpect
 playwright
 tenacity
+starlette
+pydantic
+pydantic-core
+typing-extensions
+typing-inspection
+annotated-types
+sniffio
+exceptiongroup


### PR DESCRIPTION
This commit streamlines the project's build process by:

1.  Modifying the `Makefile` to solely utilize `uv` for virtual environment creation (`uv venv .venv`) and dependency synchronization (`uv pip sync requirements.txt`).
2.  Removing the previous `install-uv` target and the explicit check for `.venv` directory existence, relying on `uv`'s capabilities.
3.  Updating `requirements.txt` to include direct dependencies that were previously transitive. This ensures `uv pip sync` can correctly provision the environment. This change was identified and implemented during the testing of the new build process.
4.  Updating the "Setup and Running the Project" section in `README.md` to accurately reflect the new, simplified build steps and prerequisites.

The build process is now more straightforward and relies only on `uv` for managing the Python environment and dependencies, as per your original request.