### PR TITLE
Refactor: Update GitHub workflow for Python build and test

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -8,20 +8,14 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
-
-    - name: configure
-      run: ./configure
-
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
     - name: Install dependencies
-      run: make 
-
-    - name: Run check
-      run: make check
-
-    - name: Run distcheck
-      run: make distcheck
+      run: make build
+    - name: Run tests
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: build
+.PHONY: build test
 
 build:
 	@echo "Ensuring .venv is created..."
 	@uv venv .venv
 	@echo "Syncing dependencies..."
 	@uv pip sync requirements.txt
+
+test:
+	@echo "Running tests..."
+	@python -m unittest discover tests


### PR DESCRIPTION
The existing makefile.yml was not suitable for a Python project. This commit updates the workflow to:
- Set up Python 3.10.
- Install dependencies using 'make build' (which leverages uv).
- Run tests using 'make test'.

A new 'test' target was added to the Makefile to execute 'python -m unittest discover tests'.