### PR TITLE
Fix: Add pytest to requirements and ensure it's installed for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ typing-inspection
 annotated-types
 sniffio
 exceptiongroup
+pytest


### PR DESCRIPTION
The tests were failing in CI due to a missing 'pytest' dependency. This commit:
- Adds 'pytest' to 'requirements.txt'.
- Relies on the existing 'make build' step (which runs 'uv pip sync requirements.txt') in the GitHub workflow to install pytest.