### PR TITLE
Fix: Activate venv in Makefile's test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ build:
 	@echo "Ensuring .venv is created..."
 	@uv venv .venv
 	@echo "Syncing dependencies..."
-	@uv pip sync requirements.txt
+	@uv pip sync requirements.txt --python .venv/bin/python
 
 test:
-	@echo "Running tests..."
-	@python -m unittest discover tests
+	@echo "Activating virtual environment and running tests..."
+	@source .venv/bin/activate && python -m unittest discover tests


### PR DESCRIPTION
The previous CI runs failed to find pytest, likely because the virtual environment created by 'make build' was not activated for the 'make test' step.

This commit updates the 'test' target in the Makefile to explicitly source '.venv/bin/activate' before running tests.

Additionally, the 'build' target was updated to explicitly specify the Python interpreter for 'uv pip sync' using '--python .venv/bin/python' for robustness.