### PR TITLE
Fix: Use POSIX-compliant venv activation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ build:
 
 test:
 	@echo "Activating virtual environment and running tests..."
-	@source .venv/bin/activate && python -m unittest discover tests
+	@. .venv/bin/activate && python -m unittest discover tests


### PR DESCRIPTION
The 'make test' command was failing in CI with 'source: not found' because 'make' defaults to 'sh', and 'source' is a bashism.

This commit updates the 'test' target in the Makefile to use the POSIX-compliant '.' command for sourcing the virtual environment activation script. This ensures that 'pytest' (installed in the venv) is found during testing.