### PR TITLE
Fix: Add pluggy as explicit dependency for pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ annotated-types
 sniffio
 exceptiongroup
 pytest
+pluggy


### PR DESCRIPTION
The CI tests failed because 'pluggy', a dependency of 'pytest', was not found. While package managers like pip/uv usually handle transitive dependencies, explicitly adding 'pluggy' to 'requirements.txt' ensures it is installed.

This commit adds 'pluggy' to 'requirements.txt'.