### PR TITLE
Fix: Add iniconfig as explicit dependency for pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ exceptiongroup
 pytest
 pluggy
 pygments
+iniconfig


### PR DESCRIPTION
The CI tests continued to fail due to missing pytest dependencies. This time, 'iniconfig' was not found.

This commit adds 'iniconfig' to 'requirements.txt' to ensure it is installed. If further dependency issues arise, a more comprehensive pytest installation strategy will be adopted.