### PR TITLE
Fix: Correct import paths in test_message_history.py

### DIFF
--- a/tests/test_message_history.py
+++ b/tests/test_message_history.py
@@ -1,11 +1,11 @@
 import pytest
-from ii_agent.llm.base import (
+from llm.base import (
     TextPrompt,
     TextResult,
     ToolCall,
     ToolFormattedResult,
 )
-from ii_agent.llm.message_history import MessageHistory
+from llm.message_history import MessageHistory
 
 
 @pytest.fixture


### PR DESCRIPTION
The tests were failing with a ModuleNotFoundError because they were trying to import from 'ii_agent.llm', which does not exist. The correct top-level package for llm related modules is 'llm'.

This commit updates the import statements in
'tests/test_message_history.py' to use 'from llm...' instead of 'from ii_agent.llm...'.