### PR TITLE
Fix: Add marshmallow as explicit dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ datasets
 jsonschema
 anthropic
 dataclasses-json
+marshmallow
 openai
 google-generativeai
 Pillow


### PR DESCRIPTION
The CI tests failed because 'marshmallow', a dependency of 'dataclasses-json', was not found. This continues a pattern of transitive dependencies not being fully resolved by the current 'uv pip sync' setup.

This commit adds 'marshmallow' explicitly to 'requirements.txt'.